### PR TITLE
add ReadStringAsSlice compatibility with upstream

### DIFF
--- a/iter_str.go
+++ b/iter_str.go
@@ -25,6 +25,7 @@ func (iter *Iterator) ReadString() string {
 
 // ReadStringAsSlice read string from iterator without copying into string form.
 // The []byte can not be kept, as it will change after next iterator call.
+// DEPRECATED: Use ReadRawString instead
 func (iter *Iterator) ReadStringAsSlice() (ret []byte) {
 	return iter.ReadRawString().buf
 }

--- a/iter_str.go
+++ b/iter_str.go
@@ -23,6 +23,12 @@ func (iter *Iterator) ReadString() string {
 	return iter.readStringInner()
 }
 
+// ReadStringAsSlice read string from iterator without copying into string form.
+// The []byte can not be kept, as it will change after next iterator call.
+func (iter *Iterator) ReadStringAsSlice() (ret []byte) {
+	return iter.ReadRawString().buf
+}
+
 func (iter *Iterator) readStringInner() string {
 	sb := strings.Builder{}
 

--- a/misc_tests/jsoniter_iterator_test.go
+++ b/misc_tests/jsoniter_iterator_test.go
@@ -22,7 +22,7 @@ func Test_bad_case(t *testing.T) {
 			for iter.ReadArray() {
 				for field, _ := iter.ReadObject(); field != ""; field, _ = iter.ReadObject() {
 					if field == "Bit" {
-						iter.ReadRawString()
+						iter.ReadStringAsSlice()
 					} else {
 						if field != "Size" && field != "EndIndex" && field != "EndMask" && field != "Good" && field != "Flush" {
 							t.Fatal(field)


### PR DESCRIPTION
This function is missing from the iter struct but is found upstream https://pkg.go.dev/github.com/json-iterator/go#Iterator.ReadStringAsSlice

Added it in to ensure that modules that depend on jsoniter and use this function are okay with this fork. 

Modified the jsonter_iterator_test.go file to use this function, that's what upstream does in that same test file