### PR TITLE
Added Iterator.Buffered

### DIFF
--- a/api_tests/iter_test.go
+++ b/api_tests/iter_test.go
@@ -93,3 +93,166 @@ func Test_iterator_offsets(t *testing.T) {
 	should.EqualValues(len(json), iter.InputOffset())
 	should.EqualError(iter.Error, io.EOF.Error())
 }
+
+func TestIterator_Buffered(t *testing.T) {
+	should := require.New(t)
+
+	t.Run("empty buffer", func(t *testing.T) {
+		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, []byte{})
+		buffered := iter.Buffered()
+		should.NotNil(buffered)
+
+		// Read from empty buffered reader should return 0 and EOF
+		buf, err := io.ReadAll(buffered)
+		should.NoError(err)
+		should.Len(buf, 0)
+	})
+
+	t.Run("no data consumed", func(t *testing.T) {
+		input := []byte(`{"key": "value"}`)
+		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, input)
+		should.Equal(jsoniter.ObjectValue, iter.WhatIsNext())
+		buffered := iter.Buffered()
+		should.NotNil(buffered)
+
+		// All data should be available in buffered reader
+		buf, err := io.ReadAll(buffered)
+		should.NoError(err)
+		should.Equal(string(input), string(buf))
+	})
+
+	t.Run("partial data consumed", func(t *testing.T) {
+		input := []byte(`{"key": "value", "num": 123}`)
+		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, input)
+
+		// Consume first key-value pair
+		iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+			iter.Skip()
+			return false
+		})
+		should.NoError(iter.Error)
+
+		// Get buffered reader after partial consumption
+		buffered := iter.Buffered()
+		should.NotNil(buffered)
+
+		// Should contain remaining unread data
+		buf, err := io.ReadAll(buffered)
+		should.NoError(err)
+		// After consuming first key-value pair, remaining should contain the rest
+		should.Equal(`, "num": 123}`, string(buf))
+	})
+
+	t.Run("all data consumed", func(t *testing.T) {
+		input := []byte(`{"key": "value"}`)
+		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, input)
+
+		// Consume all data
+		iter.Skip()
+		should.NoError(iter.Error)
+
+		// Get buffered reader after all data consumed
+		buffered := iter.Buffered()
+		should.NotNil(buffered)
+
+		// Should be empty
+		buf, err := io.ReadAll(buffered)
+		should.Len(buf, 0)
+		should.NoError(err)
+	})
+
+	t.Run("iterator reset", func(t *testing.T) {
+		input := []byte(`{"key": "value", "num": 123}`)
+		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, input)
+
+		// Consume first key-value pair
+		iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+			iter.Skip()
+			return false
+		})
+		should.NoError(iter.Error)
+
+		// Get buffered reader after partial consumption
+		buffered := iter.Buffered()
+		should.NotNil(buffered)
+
+		iter.ResetBytes([]byte(`null`))
+		should.Equal(jsoniter.NilValue, iter.WhatIsNext())
+		should.EqualValues(0, iter.InputOffset())
+
+		buf, err := io.ReadAll(buffered)
+		should.NoError(err)
+		should.Equal(`, "num": 123}`, string(buf))
+	})
+
+	t.Run("with streaming reader", func(t *testing.T) {
+		input := `{"key1": "value1", "key2": "value2", "key3": "value3"}`
+		reader := strings.NewReader(input)
+		iter := jsoniter.Parse(jsoniter.ConfigDefault, reader, 1024)
+
+		// Consume first key-value pair
+		iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+			iter.Skip()
+			return false
+		})
+		should.NoError(iter.Error)
+
+		// Get buffered reader
+		buffered := iter.Buffered()
+		should.NotNil(buffered)
+
+		// Should contain remaining data
+		buf, err := io.ReadAll(buffered)
+		should.NoError(err)
+		should.Equal(`, "key2": "value2", "key3": "value3"}`, string(buf))
+	})
+
+	t.Run("buffered reader after error", func(t *testing.T) {
+		input := []byte(`{"key": "value"  123`) // Invalid JSON - missing closing brace
+		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, input)
+
+		// Try to read which should cause an error
+		iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+			iter.Skip()
+			return true
+		})
+		// Iterator should have an error due to malformed JSON
+		should.Error(iter.Error)
+
+		// Buffered reader should still work
+		buffered := iter.Buffered()
+		should.NotNil(buffered)
+
+		// Should be able to read whatever is buffered
+		buf, err := io.ReadAll(buffered)
+		should.NoError(err)
+		should.Equal("123", string(buf))
+	})
+
+	t.Run("consistency with standard library behavior", func(t *testing.T) {
+		input := []byte(`{"key": "value", "num": 123}`)
+		iter := jsoniter.ParseBytes(jsoniter.ConfigDefault, input)
+
+		// Consume some data
+		iter.ReadObjectCB(func(iter *jsoniter.Iterator, key string) bool {
+			iter.Skip()
+			return false
+		})
+		should.NoError(iter.Error)
+
+		// Get buffered reader
+		buffered1 := iter.Buffered()
+		buffered2 := iter.Buffered()
+
+		// Each call should return a new reader
+		should.NotSame(buffered1, buffered2)
+
+		// Both should have the same content
+		buf1, err1 := io.ReadAll(buffered1)
+		buf2, err2 := io.ReadAll(buffered2)
+
+		should.NoError(err1)
+		should.NoError(err2)
+		should.Equal(string(buf1), string(buf2))
+	})
+}

--- a/iter.go
+++ b/iter.go
@@ -1,6 +1,7 @@
 package jsoniter
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -147,6 +148,15 @@ func (iter *Iterator) InputOffset() int64 {
 	return iter.inputOffset + int64(iter.head)
 }
 
+// Buffered returns a reader of the data remaining in the Iterator's buffer.
+func (iter *Iterator) Buffered() io.Reader {
+	// we make a copy of the data, so callers can Reset this Iterator
+	// and operate on the same data without data races
+	buf := make([]byte, iter.tail-iter.head)
+	copy(buf, iter.buf[iter.head:iter.tail])
+	return bytes.NewReader(buf)
+}
+
 func (iter *Iterator) isNextTokenBuffered() bool {
 	for i := iter.head; i < iter.tail; i++ {
 		c := iter.buf[i]
@@ -268,7 +278,6 @@ func (iter *Iterator) unreadByte() {
 		return
 	}
 	iter.head--
-	return
 }
 
 // Read read the next JSON element as generic interface{}.

--- a/iter_array.go
+++ b/iter_array.go
@@ -19,6 +19,7 @@ func (iter *Iterator) ReadArray() (ret bool) {
 	case ',':
 		return true
 	default:
+		iter.unreadByte()
 		iter.ReportError("ReadArray", "expect [ or , or ] or n, but found "+string([]byte{c}))
 		return
 	}
@@ -47,6 +48,7 @@ func (iter *Iterator) ReadArrayCB(callback func(*Iterator) bool) (ret bool) {
 				c = iter.nextToken()
 			}
 			if c != ']' {
+				iter.unreadByte()
 				iter.ReportError("ReadArrayCB", "expect ] in the end, but found "+string([]byte{c}))
 				iter.decrementDepth()
 				return false
@@ -59,6 +61,7 @@ func (iter *Iterator) ReadArrayCB(callback func(*Iterator) bool) (ret bool) {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return true // null
 	}
+	iter.unreadByte()
 	iter.ReportError("ReadArrayCB", "expect [ or n, but found "+string([]byte{c}))
 	return false
 }

--- a/iter_object.go
+++ b/iter_object.go
@@ -33,6 +33,7 @@ func (iter *Iterator) ReadObjectRaw() RawString {
 			}
 			c = iter.nextToken()
 			if c != ':' {
+				iter.unreadByte()
 				iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 			}
 			return rs
@@ -49,12 +50,14 @@ func (iter *Iterator) ReadObjectRaw() RawString {
 		}
 		c = iter.nextToken()
 		if c != ':' {
+			iter.unreadByte()
 			iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 		}
 		return rs
 	case '}':
 		return RawString{} // end of object
 	default:
+		iter.unreadByte()
 		iter.ReportError("ReadObject", fmt.Sprintf(`expect { or , or } or n, but found %s`, string([]byte{c})))
 		return RawString{}
 	}
@@ -65,6 +68,7 @@ func (iter *Iterator) readFieldHash() int64 {
 	hash := int64(0x811c9dc5)
 	c := iter.nextToken()
 	if c != '"' {
+		iter.unreadByte()
 		iter.ReportError("readFieldHash", `expect ", but found `+string([]byte{c}))
 		return 0
 	}
@@ -83,6 +87,7 @@ func (iter *Iterator) readFieldHash() int64 {
 				}
 				c = iter.nextToken()
 				if c != ':' {
+					iter.unreadByte()
 					iter.ReportError("readFieldHash", `expect :, but found `+string([]byte{c}))
 					return 0
 				}
@@ -92,6 +97,7 @@ func (iter *Iterator) readFieldHash() int64 {
 				iter.head = i + 1
 				c = iter.nextToken()
 				if c != ':' {
+					iter.unreadByte()
 					iter.ReportError("readFieldHash", `expect :, but found `+string([]byte{c}))
 					return 0
 				}
@@ -144,6 +150,7 @@ func (iter *Iterator) ReadObjectRawCB(callback func(*Iterator, RawString) bool) 
 			}
 			c = iter.nextToken()
 			if c != ':' {
+				iter.unreadByte()
 				iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 				return false
 			}
@@ -159,6 +166,7 @@ func (iter *Iterator) ReadObjectRawCB(callback func(*Iterator, RawString) bool) 
 				}
 				c = iter.nextToken()
 				if c != ':' {
+					iter.unreadByte()
 					iter.ReportError("ReadObject", "expect : after object field, but found "+string([]byte{c}))
 					return false
 				}
@@ -169,6 +177,7 @@ func (iter *Iterator) ReadObjectRawCB(callback func(*Iterator, RawString) bool) 
 				c = iter.nextToken()
 			}
 			if c != '}' {
+				iter.unreadByte()
 				iter.ReportError("ReadObjectCB", `object not ended with }`)
 				return false
 			}
@@ -177,6 +186,7 @@ func (iter *Iterator) ReadObjectRawCB(callback func(*Iterator, RawString) bool) 
 		if c == '}' {
 			return iter.decrementDepth()
 		}
+		iter.unreadByte()
 		iter.ReportError("ReadObjectCB", `expect " after {, but found `+string([]byte{c}))
 		iter.decrementDepth()
 		return false
@@ -185,6 +195,7 @@ func (iter *Iterator) ReadObjectRawCB(callback func(*Iterator, RawString) bool) 
 		iter.skipThreeBytes('u', 'l', 'l')
 		return true // null
 	}
+	iter.unreadByte()
 	iter.ReportError("ReadObjectCB", `expect { or n, but found `+string([]byte{c}))
 	return false
 }
@@ -219,7 +230,7 @@ func (iter *Iterator) isObjectEnd() bool {
 	if c == '}' {
 		return true
 	}
-
+	iter.unreadByte()
 	iter.ReportError("isObjectEnd", "object ended prematurely, unexpected char "+string([]byte{c}))
 	return true
 }

--- a/iter_skip.go
+++ b/iter_skip.go
@@ -92,6 +92,7 @@ func (iter *Iterator) Skip() {
 	case '{':
 		iter.skipObject()
 	default:
+		iter.unreadByte()
 		iter.ReportError("Skip", fmt.Sprintf("do not know how to skip: %v", c))
 		return
 	}

--- a/iter_str.go
+++ b/iter_str.go
@@ -16,6 +16,7 @@ func (iter *Iterator) ReadString() string {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return ""
 	default:
+		iter.unreadByte()
 		iter.ReportError("ReadString", `expects " or n, but found `+string([]byte{c}))
 		return ""
 	}
@@ -89,6 +90,7 @@ func (iter *Iterator) ReadRawString() RawString {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return RawString{}
 	default:
+		iter.unreadByte()
 		iter.ReportError("ReadRawString", `expects " or n, but found `+string([]byte{c}))
 		return RawString{}
 	}


### PR DESCRIPTION
### Summary
This PR adds a new `Buffered()` method to the Iterator that mimics the behavior of Go's standard library `json.Decoder.Buffered()`.

### Changes

#### ✨ New Feature: Iterator.Buffered() method
- **Added `Iterator.Buffered() io.Reader`** - Returns a reader of the data remaining in the Iterator's buffer
- **Standard library compatibility** - Matches the behavior of `json.Decoder.Buffered()` from Go's standard library

#### 🐛 Bug Fixes: Error Position Reporting
Fixed multiple instances of missing `iter.unreadByte()` calls, which allow using the Buffered more effectively.

These fixes ensure that when parsing errors occur, the iterator can return buffer including the problematic character rather than the character after it.

### Use Cases
The `Buffered()` method enables:
- **Incremental parsing**: Process JSON incrementally while preserving unread data
- **Parser chaining**: Pass remaining data to other parsers or processors  
- **Debugging**: Inspect remaining unparsed data for troubleshooting

### Testing
- All new functionality is covered by comprehensive unit tests